### PR TITLE
Enable Automatic versioning

### DIFF
--- a/ios/ShoutemApp.xcodeproj/project.pbxproj
+++ b/ios/ShoutemApp.xcodeproj/project.pbxproj
@@ -852,6 +852,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ShoutemApp/ShoutemApp.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -876,6 +877,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = ShoutemApp;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
 		};
@@ -884,6 +886,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ShoutemApp/ShoutemApp.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -907,6 +910,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = ShoutemApp;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
In order to allow build tools to automatically adapt the build number two buildSettings are required:
- `CURRENT_PROJECT_VERSION`
- `VERSIONING_SYSTEM`

For reference see: https://developer.apple.com/library/content/qa/qa1827/_index.html