### PR TITLE
HC/Remove appetize key placeholders

### DIFF
--- a/platform/platform.json
+++ b/platform/platform.json
@@ -3,9 +3,6 @@
   "mobileAppVersion": "1.7.2-rc.6",
   "releaseNotes": "* Various iPhone X styling improvements\n* Status bar color picker for style customization\n* Bugfixes and improvements",
   "settings": {
-    "DEV-appetizeKey": "60571c8y46jmpfuhutuc18debr",
-    "QA-appetizeKey": "m928k61m2ch21vdtadc9466x8c",
-    "Production-appetizeKey": "wxzyu8w84b3jp0xk5v4zjfbrug"
   },
   "builds": {
     "live": {


### PR DESCRIPTION
I'd like to merge this into this release so it can propagate through apps(in which it gets installed) a bit before we release custom platform. It shouldn't have any tangible effect so should do no harm even though custom platform's not out yet.