### PR TITLE
Hotfix/2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Podfile
 ios/Pods
 ios/Podfile.lock
 config/
+dependencies.json
 
 # Logs
 logs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1-rc.1",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "setup": "cd scripts && yarn install",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@shoutem/platform",
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "setup": "cd scripts && yarn install",
     "lint": "eslint .",
     "configure": "node scripts/configure",
     "bundle": "node scripts/bundle",
-    "build": "node scripts/build"
+    "build": "node scripts/build",
+    "list-dependencies": "node scripts/platform-dependencies"
   },
   "dependencies": {
     "es6-symbol": "3.1.1",
@@ -36,6 +37,7 @@
     "@shoutem/build-tools": "file:scripts/helpers",
     "babel-eslint": "^9.0.0",
     "babel-jest": "^24.8.0",
+    "babel-plugin-jest-hoist": "^24.0.0",
     "eslint": "~5.15.1",
     "eslint-config-airbnb": "~17.1.0",
     "eslint-plugin-import": "~2.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "2.1.1-rc.1",
+  "version": "2.1.1",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "setup": "cd scripts && yarn install",

--- a/package.template.json
+++ b/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1-rc.1",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "setup": "cd scripts && yarn install",

--- a/package.template.json
+++ b/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "2.1.1-rc.1",
+  "version": "2.1.1",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "setup": "cd scripts && yarn install",

--- a/package.template.json
+++ b/package.template.json
@@ -1,13 +1,14 @@
 {
   "name": "@shoutem/platform",
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "setup": "cd scripts && yarn install",
     "lint": "eslint .",
     "configure": "node scripts/configure",
     "bundle": "node scripts/bundle",
-    "build": "node scripts/build"
+    "build": "node scripts/build",
+    "list-dependencies": "node scripts/platform-dependencies"
   },
   "dependencies": {
     "es6-symbol": "3.1.1",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.1.0",
+  "version": "2.1.1-rc.0",
   "mobileAppVersion": "2.1.0",
-  "releaseNotes": "NOTE! The following extensions must be uninstalled for this platform; Shopify, Google Analytics and Shoutem Platform Analytics. For help with uninstalling them, feel free to contact Shoutem support via support@shoutem.com\n* '@shoutem/ui' version 1.0.0 with FlatList and SectionList refactor\n* upgrade to React Native 0.59.10\n* Android 64 bit support\n* New Android JavaScript core - improved performance\n* Switch to react-native-webview\n* Switch to @react-native-community/async-storage",
+  "releaseNotes": "* Shopify extension reintroduction\n* bugixes and improvements\n",
   "settings": {
     "DEV-appetizeKey": "90dycv9gb098u6xytcb6jnkvw8",
     "QA-appetizeKey": "p21k4z0quazqthk8czw28t6q04",
@@ -56,6 +56,7 @@
     "shoutem.rss-photos": "~2.1.0",
     "shoutem.rss-videos": "~2.1.0",
     "shoutem.rubicon-theme": "~2.1.0",
+    "shoutem.shopify": "~2.1.0",
     "shoutem.social": "~2.1.0",
     "shoutem.sub-navigation": "~2.1.0",
     "shoutem.theme": "~2.1.0",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.1.1-rc.0",
+  "version": "2.1.1-rc.1",
   "mobileAppVersion": "2.1.0",
-  "releaseNotes": "* Shopify extension reintroduction\n* bugixes and improvements\n",
+  "releaseNotes": "* Shopify extension reintroduction\n* Bugixes and improvements",
   "settings": {
     "DEV-appetizeKey": "90dycv9gb098u6xytcb6jnkvw8",
     "QA-appetizeKey": "p21k4z0quazqthk8czw28t6q04",
@@ -24,7 +24,7 @@
   "dependencies": {
     "shoutem.about": "~2.1.0",
     "shoutem.analytics": "~2.1.0",
-    "shoutem.application": "~2.1.0",
+    "shoutem.application": ">=2.1.9",
     "shoutem.auth": "~2.1.0",
     "shoutem.books": "~2.1.0",
     "shoutem.camera": "~2.1.0",
@@ -55,7 +55,7 @@
     "shoutem.rss-news": "~2.1.0",
     "shoutem.rss-photos": "~2.1.0",
     "shoutem.rss-videos": "~2.1.0",
-    "shoutem.rubicon-theme": "~2.1.0",
+    "shoutem.rubicon-theme": ">=2.1.7",
     "shoutem.shopify": "~2.1.0",
     "shoutem.social": "~2.1.0",
     "shoutem.sub-navigation": "~2.1.0",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.1-rc.1",
+  "version": "2.1.1",
   "mobileAppVersion": "2.1.0",
   "releaseNotes": "* Shopify extension reintroduction\n* Bugixes and improvements",
   "settings": {
@@ -28,7 +28,7 @@
     "shoutem.auth": "~2.1.0",
     "shoutem.books": "~2.1.0",
     "shoutem.camera": "~2.1.0",
-    "shoutem.cms": "~2.1.0",
+    "shoutem.cms": "=>2.1.2",
     "shoutem.code-push": "~2.1.0",
     "shoutem.deals": "~2.1.0",
     "shoutem.events": "~2.1.0",
@@ -56,7 +56,7 @@
     "shoutem.rss-photos": "~2.1.0",
     "shoutem.rss-videos": "~2.1.0",
     "shoutem.rubicon-theme": ">=2.1.7",
-    "shoutem.shopify": "~2.1.0",
+    "shoutem.shopify": ">=2.1.11",
     "shoutem.social": "~2.1.0",
     "shoutem.sub-navigation": "~2.1.0",
     "shoutem.theme": "~2.1.0",

--- a/scripts/platform-dependencies.js
+++ b/scripts/platform-dependencies.js
@@ -1,0 +1,63 @@
+const fs = require('fs-extra');
+
+const DEPENDENCIES_FILE_PATH = './dependencies.json';
+const EXT_PATH_ROOT = './extensions/';
+const EXT_PACKAGE_PATH = '/app/package.json';
+const PACKAGE_STRING = 'package.json';
+const PLATFORM_PATH = './platform/platform.json';
+
+// returns array of extensions from platform.json dependencies
+function fetchPlatformExtensions() {
+  const platformJson = fs.readJsonSync(PLATFORM_PATH);
+
+  return Object.keys(platformJson.dependencies);
+}
+
+// returns all extensions found in the ./extensions directory
+// currently unused due to deprecated extensions in the directory
+function fetchAllExtensions() {
+  const listOfExtensions = fs.readdirSync(EXT_PATH_ROOT, { withFileTypes: true })
+    .filter(file => file.startsWith('shoutem.'))
+
+  return listOfExtensions;
+}
+
+// returns all dependencies of a specific extension
+function fetchExtensionDependencies(extName) {
+  const extPackageJson = fs.readJsonSync(EXT_PATH_ROOT + extName + EXT_PACKAGE_PATH);
+
+  return extPackageJson.dependencies;
+}
+
+// returns all dependencies specified in root app package.json
+function fetchPlatformDependencies() {
+  const platformPackageJson = fs.readJsonSync(PACKAGE_STRING);
+
+  return platformPackageJson.dependencies;
+}
+
+function makeList() {
+  const listOfExtensions = fetchPlatformExtensions();
+
+  let listOfDependencies = {};
+  listOfExtensions.forEach(extension => {
+    const extName = extension === 'shoutem.video' ? 'shoutem.videos' : extension;
+
+    listOfDependencies = {
+      ...listOfDependencies,
+      ...fetchExtensionDependencies(extName),
+    };
+  });
+
+  listOfDependencies = {
+    ...listOfDependencies,
+    ...fetchPlatformDependencies(),
+  }
+
+  const list = JSON.stringify(listOfDependencies, Object.keys(listOfDependencies).sort(), 2);
+
+  fs.writeFileSync(DEPENDENCIES_FILE_PATH, list);
+  console.log("Wrote list of platform and extension dependencies into 'dependencies.json'");
+}
+
+makeList();


### PR DESCRIPTION
Introduce `platform-dependencies` script to generate all dependencies found in platform and `extension/app` `package.json` files:
`npm run list-dependencies` generates a `dependencies.json` file in the root folder of the app.

Update extension versions in `platform.json` file to ensure latest necessary updates for all users, as well as reintroducing a functional `shoutem.shopify` extension.