### PR TITLE
remove flipper and flurry analytics

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -153,7 +153,6 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
-    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}")
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
     } else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "list-dependencies": "node scripts/platform-dependencies",
     "postinstall": "node scripts/postinstall",
     "setup": "cd scripts && yarn install",
-    "start": "react-native start"
+    "start": "react-native start --experimental-debugger"
   },
   "dependencies": {
     "auto-bind": "4.0.0",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -33,7 +33,6 @@
     "shoutem.events": "~5.2.0",
     "shoutem.favorites": "~6.0.2-rc.0",
     "shoutem.firebase": "~5.1.0-rc.0",
-    "shoutem.flurry-analytics": "~4.4.1-rc.0",
     "shoutem.fonts": "~2.0.2-rc.0",
     "shoutem.google-analytics": "~3.1.0-rc.0",
     "shoutem.i18n": "~4.1.3-rc.0",


### PR DESCRIPTION
## Summary

- Removed deprecated `shoutem.flutty-analytics` from platform dependencies
- Added `--experimental-debugger` flag into `start` script