### PR TITLE
Hotfix/17.0.3

### DIFF
--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+<FrameLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical"
+>
+  <ImageView 
+    android:src="@drawable/launch_screen"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/splash">
-</LinearLayout>
+    android:scaleType="centerCrop"
+  >
+  </ImageView>
+</FrameLayout>

--- a/android/app/src/main/res/layout/launch_screen.xml
+++ b/android/app/src/main/res/layout/launch_screen.xml
@@ -6,7 +6,7 @@
   android:orientation="vertical"
 >
   <ImageView 
-    android:src="@drawable/launch_screen"
+    android:src="@drawable/splash"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:scaleType="centerCrop"

--- a/ios/ShoutemApp/Info.plist
+++ b/ios/ShoutemApp/Info.plist
@@ -65,10 +65,6 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>arm64</string>
-	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.3-rc.1",
+  "version": "17.0.3",
   "scripts": {
     "android": "react-native run-android",
     "build": "node scripts/build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.3-rc.0",
+  "version": "17.0.3-rc.1",
   "scripts": {
     "android": "react-native run-android",
     "build": "node scripts/build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.2",
+  "version": "17.0.3-rc.0",
   "scripts": {
     "android": "react-native run-android",
     "build": "node scripts/build",

--- a/package.template.json
+++ b/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.3-rc.1",
+  "version": "17.0.3",
   "scripts": {
     "android": "react-native run-android",
     "build": "node scripts/build",

--- a/package.template.json
+++ b/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.3-rc.0",
+  "version": "17.0.3-rc.1",
   "scripts": {
     "android": "react-native run-android",
     "build": "node scripts/build",

--- a/package.template.json
+++ b/package.template.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.2",
+  "version": "17.0.3-rc.0",
   "scripts": {
     "android": "react-native run-android",
     "build": "node scripts/build",

--- a/package.template.web.json
+++ b/package.template.web.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.3-rc.1",
+  "version": "17.0.3",
   "scripts": {
     "build": "node scripts/build",
     "bundle": "node scripts/bundle",

--- a/package.template.web.json
+++ b/package.template.web.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.2",
+  "version": "17.0.3-rc.0",
   "scripts": {
     "build": "node scripts/build",
     "bundle": "node scripts/bundle",

--- a/package.template.web.json
+++ b/package.template.web.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/platform",
-  "version": "17.0.3-rc.0",
+  "version": "17.0.3-rc.1",
   "scripts": {
     "build": "node scripts/build",
     "bundle": "node scripts/bundle",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,5 +1,5 @@
 {
-  "version": "17.0.3-rc.0",
+  "version": "17.0.3-rc.1",
   "releaseNotes": "Release notes\n* Removed UIRequiredDeviceCapabilities from iOS Info.plist due to App Store rejection (Guideline 2.3 - Accurate Metadata).\n* Fixed stretched Android launch screen.",
   "builds": {
     "live": {
@@ -7,7 +7,7 @@
     }
   },
   "nativeChanges": {
-    "lastVersion": "17.0.3-rc.0"
+    "lastVersion": "17.0.3-rc.1"
   },
   "dependencies": {
     "shoutem.about": "~9.0.3",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,13 +1,13 @@
 {
-  "version": "17.0.2",
-  "releaseNotes": "Release notes\n* Fixed map marker issues.\n\nApp Build improvements\n* Improved App build scripts",
+  "version": "17.0.3-rc.0",
+  "releaseNotes": "Release notes\n* Removed UIRequiredDeviceCapabilities from iOS Info.plist due to App Store rejection (Guideline 2.3 - Accurate Metadata) ",
   "builds": {
     "live": {
       "excludedPackages": []
     }
   },
   "nativeChanges": {
-    "lastVersion": "17.0.2"
+    "lastVersion": "17.0.3-rc.0"
   },
   "dependencies": {
     "shoutem.about": "~9.0.3",
@@ -18,7 +18,7 @@
     "shoutem.analytics": "~5.1.1",
     "shoutem.application": "~7.5.2",
     "shoutem.audio": "~9.0.0",
-    "shoutem.auth": "~11.0.1",
+    "shoutem.auth": "~11.0.2",
     "shoutem.bands-in-town": "~2.0.0",
     "shoutem.besttime": "~6.0.0",
     "shoutem.books": "~7.0.0",
@@ -27,7 +27,7 @@
     "shoutem.checklist": "~6.0.0",
     "shoutem.cms": "~8.0.5",
     "shoutem.deals": "~8.1.1",
-    "shoutem.events": "~6.1.3",
+    "shoutem.events": "~6.2.0",
     "shoutem.favorites": "~7.0.0",
     "shoutem.firebase": "~7.0.0",
     "shoutem.fonts": "~3.0.0",
@@ -37,7 +37,7 @@
     "shoutem.ical-events": "~6.0.2",
     "shoutem.in-app-purchases": "~7.3.0",
     "shoutem.interactive-faq": "~8.0.1",
-    "shoutem.layouts": "~8.1.0",
+    "shoutem.layouts": "~8.1.1",
     "shoutem.live-update": "~2.1.0",
     "shoutem.loyalty": "~8.0.3",
     "shoutem.menu": "~6.0.0",
@@ -50,8 +50,8 @@
     "shoutem.permissions": "~7.1.0",
     "shoutem.persist": "~5.0.0",
     "shoutem.photos": "~6.0.1",
-    "shoutem.places": "~8.1.0",
-    "shoutem.podcast": "~12.1.5",
+    "shoutem.places": "~8.2.0",
+    "shoutem.podcast": "~13.0.1",
     "shoutem.preview": "~7.1.1",
     "shoutem.products": "~6.0.0",
     "shoutem.push-notifications": "~5.0.3",
@@ -68,21 +68,21 @@
     "shoutem.shopify": "~11.1.0",
     "shoutem.social": "~16.0.1",
     "shoutem.sub-navigation": "~5.1.0",
-    "shoutem.theme": "~9.1.4",
-    "shoutem.user-profile": "~6.3.0",
+    "shoutem.theme": "~9.1.6",
+    "shoutem.user-profile": "~6.3.2",
     "shoutem.video": "~8.0.1",
-    "shoutem.web-view": "~10.0.0",
+    "shoutem.web-view": "~10.0.1",
     "shoutem.wordpress": "~6.0.1",
     "shoutem.youtube": "~6.0.1"
   },
   "requiredDependencies": {
     "shoutem.application": "~7.5.2",
     "shoutem.i18n": "~5.0.1",
-    "shoutem.layouts": "~8.1.0",
+    "shoutem.layouts": "~8.1.1",
     "shoutem.navigation": "~7.3.0",
     "shoutem.redux": "~5.0.3",
     "shoutem.sub-navigation": "~5.1.0",
-    "shoutem.theme": "~9.1.4"
+    "shoutem.theme": "~9.1.6"
   },
   "archivedDependencies": [
     "shoutem.flurry-analytics",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,5 +1,5 @@
 {
-  "version": "17.0.3-rc.1",
+  "version": "17.0.3",
   "releaseNotes": "Release notes\n* Removed UIRequiredDeviceCapabilities from iOS Info.plist due to App Store rejection (Guideline 2.3 - Accurate Metadata).\n* Fixed stretched Android launch screen.",
   "builds": {
     "live": {
@@ -7,7 +7,7 @@
     }
   },
   "nativeChanges": {
-    "lastVersion": "17.0.3-rc.1"
+    "lastVersion": "17.0.3"
   },
   "dependencies": {
     "shoutem.about": "~9.0.3",

--- a/platform/platform.json
+++ b/platform/platform.json
@@ -1,6 +1,6 @@
 {
   "version": "17.0.3-rc.0",
-  "releaseNotes": "Release notes\n* Removed UIRequiredDeviceCapabilities from iOS Info.plist due to App Store rejection (Guideline 2.3 - Accurate Metadata) ",
+  "releaseNotes": "Release notes\n* Removed UIRequiredDeviceCapabilities from iOS Info.plist due to App Store rejection (Guideline 2.3 - Accurate Metadata).\n* Fixed stretched Android launch screen.",
   "builds": {
     "live": {
       "excludedPackages": []


### PR DESCRIPTION
## Summary
- Removed UIRequiredDeviceCapabilities due to App Store rejection (Guideline 2.3 - Accurate Metadata)
- Fixed stretched Android splash screen